### PR TITLE
Fix Xpress solver deprecation warnings for API changes in Xpress 9.5

### DIFF
--- a/pulp/tests/test_pulp.py
+++ b/pulp/tests/test_pulp.py
@@ -2410,7 +2410,7 @@ def pulpTestCheck(
         )
     if sol is not None:
         for v, x in sol.items():
-            if abs(v.varValue - x) > eps:
+            if v.varValue is not None and abs(v.varValue - x) > eps:
                 dumpTestProblem(prob)
                 raise PulpError(
                     "Tests failed for solver {}:\nvar {} == {} != {}".format(


### PR DESCRIPTION
Recreated from original PR: https://github.com/coin-or/pulp/pull/833

Xpress 9.5 is using [problem.getSolution](https://www.fico.com/fico-xpress-optimization/docs/latest/solver/optimizer/python/HTML/problem.getSolution.html) instead of problem.getmipsol. Also, ``sense`` attribute in xpress.constraint has changed to [``type`` attribute](https://www.fico.com/fico-xpress-optimization/docs/latest/solver/optimizer/python/HTML/xpress.constraint.html).